### PR TITLE
Changed download location as the other is not working.

### DIFF
--- a/ding_library.make
+++ b/ding_library.make
@@ -98,6 +98,6 @@ projects[views_bulk_operations][subdir] = "contrib"
 projects[views_bulk_operations][version] = "3.2"
 
 libraries[leaflet][download][type] = "get"
-libraries[leaflet][download][url] = "http://leaflet-cdn.s3.amazonaws.com/build/leaflet-0.7.2.zip"
+libraries[leaflet][download][url] = "http://cdn.leafletjs.com/downloads/leaflet-0.7.3.zip"
 libraries[leaflet][directory_name] = "leaflet"
 libraries[leaflet][destination] = "libraries"


### PR DESCRIPTION
http://platform.dandigbib.org/issues/1336

leaflet-cdn.s3.amazonaws.com doesn't contain the leaflet library anymore.

The pull request fixes this.